### PR TITLE
Clippables: place dispatch tables adjacently.

### DIFF
--- a/preprocessor/Map Preprocessor/AppDelegate.mm
+++ b/preprocessor/Map Preprocessor/AppDelegate.mm
@@ -583,10 +583,11 @@ struct ColumnCapture {
 {
 	operations.push_back(Operation::ds_align(256));
 	operations.push_back(
-		Operation::label([NSString stringWithFormat:@"@clippable_%d_dispatch", index].UTF8String)
+		Operation::label([NSString stringWithFormat:@"clippable_%d", index].UTF8String)
 	);
 
-	operations.push_back(Operation::jp([NSString stringWithFormat:@"clippable_%d", index].UTF8String));
+	operations.push_back(Operation::nullary(Operation::Type::EX_DE_HL));
+	operations.push_back(Operation::jp([NSString stringWithFormat:@"@-clippable_full_%d", index].UTF8String));
 	operations.push_back(Operation::nullary(Operation::Type::BLANK_LINE));
 
 	// Write late starts.
@@ -734,7 +735,7 @@ struct ColumnCapture {
 		const bool is_clippable = sprite.order() != SpriteSerialiser::Order::RowsFirstDownward;
 		operations.push_back(
 			Operation::label
-				([NSString stringWithFormat:@"%s_%d", is_clippable ? "clippable" : "sprite", sprite.index()].UTF8String
+				([NSString stringWithFormat:@"%s_%d", is_clippable ? "@clippable_full" : "sprite", sprite.index()].UTF8String
 			)
 		);
 

--- a/preprocessor/Map Preprocessor/Operations/Operation.h
+++ b/preprocessor/Map Preprocessor/Operations/Operation.h
@@ -109,6 +109,8 @@ struct Operation {
 		SET7,
 		RES7,
 
+		EX_DE_HL,
+
 		BLANK_LINE,
 		NONE,
 		LABEL,
@@ -193,10 +195,11 @@ struct Operation {
 
 			case Type::NONE:
 			case Type::BLANK_LINE:	return @"";
-			case Type::RRCA:	return @"rrca";
-			case Type::RLCA:	return @"rlca";
-			case Type::CPL:		return @"cpl";
-			case Type::RET:		return @"ret";
+			case Type::RRCA:		return @"rrca";
+			case Type::RLCA:		return @"rlca";
+			case Type::CPL:			return @"cpl";
+			case Type::RET:			return @"ret";
+			case Type::EX_DE_HL:	return @"ex de, hl";
 
 			case Type::DS_ALIGN:	[text appendString:@"DS ALIGN"];	break;
 			case Type::LABEL:		return [NSString stringWithFormat:@"%@:", destination->text()];
@@ -269,12 +272,13 @@ struct Operation {
 			break;
 
 			case Type::PUSH:	return 3 + destination->index_cost();
-			case Type::ADD:		return destination->size();
-
 			case Type::SUB:
 			case Type::XOR:
 			case Type::OR:
 			case Type::AND:
+			case Type::ADD:		return 1 + destination->size();
+
+			case Type::EX_DE_HL:
 			case Type::RLCA:
 			case Type::RRCA:
 			case Type::CPL:		return 1;

--- a/src/generated/sprites.z80s
+++ b/src/generated/sprites.z80s
@@ -2001,7 +2001,7 @@
 		ld (hl), d
 		ret
 
-	clippable_1:
+	@clippable_full_1:
 		ld bc, 0x0100
 		add hl, bc
 
@@ -2327,7 +2327,7 @@
 		ld (hl), d
 		ret
 
-	clippable_0:
+	@clippable_full_0:
 		ld bc, 0x0500
 		add hl, bc
 
@@ -2607,8 +2607,9 @@
 	; The clipping functions should be called with the nominal screen destination of the top left corner
 	; in DE.
 		DS ALIGN 0x0100
-	@clippable_1_dispatch:
-		jp clippable_1
+	clippable_1:
+		ex de, hl
+		jp @-clippable_full_1
 
 		DS ALIGN 0x0010
 	clippable_1_start_after1:
@@ -2750,8 +2751,9 @@
 		ret
 
 		DS ALIGN 0x0100
-	@clippable_0_dispatch:
-		jp clippable_0
+	clippable_0:
+		ex de, hl
+		jp @-clippable_full_0
 
 		DS ALIGN 0x0010
 	clippable_0_start_after1:

--- a/src/generated/sprites.z80s
+++ b/src/generated/sprites.z80s
@@ -2612,7 +2612,6 @@
 		jp @-clippable_full_1
 
 		DS ALIGN 0x0010
-	clippable_1_start_after1:
 		ex de, hl
 		ld bc, 0x0101
 		add hl, bc
@@ -2621,7 +2620,6 @@
 		jp @-clippable_1_column1
 
 		DS ALIGN 0x0010
-	clippable_1_start_after2:
 		ex de, hl
 		ld bc, 0x0002
 		add hl, bc
@@ -2631,7 +2629,6 @@
 		jp @-clippable_1_column2
 
 		DS ALIGN 0x0010
-	clippable_1_start_after3:
 		ex de, hl
 		ld bc, 0x0003
 		add hl, bc
@@ -2641,7 +2638,6 @@
 		jp @-clippable_1_column3
 
 		DS ALIGN 0x0010
-	clippable_1_start_after4:
 		ex de, hl
 		ld bc, 0x0104
 		add hl, bc
@@ -2651,7 +2647,6 @@
 		jp @-clippable_1_column4
 
 		DS ALIGN 0x0010
-	clippable_1_start_after5:
 		ex de, hl
 		ld bc, 0x0205
 		add hl, bc
@@ -2661,7 +2656,6 @@
 		jp @-clippable_1_column5
 
 		DS ALIGN 0x0010
-	clippable_1_start_after6:
 		ex de, hl
 		ld bc, 0x0206
 		add hl, bc
@@ -2671,7 +2665,6 @@
 		jp @-clippable_1_column6
 
 		DS ALIGN 0x0010
-	clippable_1_start_after7:
 		ex de, hl
 		ld bc, 0x0307
 		add hl, bc
@@ -2681,73 +2674,66 @@
 		jp @-clippable_1_column7
 
 		DS ALIGN 0x0010
-	clippable_1_stop_after1:
 		ex de, hl
 		ld a, 0xc9
-		ld (@-clippable_1_column1), a
-		call clippable_1
+		ld (@-clippable_1_column7), a
+		call @-clippable_full_1
 		ld a, 0x36
-		ld (@-clippable_1_column1), a
+		ld (@-clippable_1_column7), a
 		ret
 
 		DS ALIGN 0x0010
-	clippable_1_stop_after2:
-		ex de, hl
-		ld a, 0xc9
-		ld (@-clippable_1_column2), a
-		call clippable_1
-		ld a, 0x36
-		ld (@-clippable_1_column2), a
-		ret
-
-		DS ALIGN 0x0010
-	clippable_1_stop_after3:
-		ex de, hl
-		ld a, 0xc9
-		ld (@-clippable_1_column3), a
-		call clippable_1
-		ld a, 0x36
-		ld (@-clippable_1_column3), a
-		ret
-
-		DS ALIGN 0x0010
-	clippable_1_stop_after4:
-		ex de, hl
-		ld a, 0xc9
-		ld (@-clippable_1_column4), a
-		call clippable_1
-		ld a, 0x36
-		ld (@-clippable_1_column4), a
-		ret
-
-		DS ALIGN 0x0010
-	clippable_1_stop_after5:
-		ex de, hl
-		ld a, 0xc9
-		ld (@-clippable_1_column5), a
-		call clippable_1
-		ld a, 0x36
-		ld (@-clippable_1_column5), a
-		ret
-
-		DS ALIGN 0x0010
-	clippable_1_stop_after6:
 		ex de, hl
 		ld a, 0xc9
 		ld (@-clippable_1_column6), a
-		call clippable_1
+		call @-clippable_full_1
 		ld a, 0x36
 		ld (@-clippable_1_column6), a
 		ret
 
 		DS ALIGN 0x0010
-	clippable_1_stop_after7:
 		ex de, hl
 		ld a, 0xc9
-		ld (@-clippable_1_column7), a
-		call clippable_1
+		ld (@-clippable_1_column5), a
+		call @-clippable_full_1
 		ld a, 0x36
-		ld (@-clippable_1_column7), a
+		ld (@-clippable_1_column5), a
+		ret
+
+		DS ALIGN 0x0010
+		ex de, hl
+		ld a, 0xc9
+		ld (@-clippable_1_column4), a
+		call @-clippable_full_1
+		ld a, 0x36
+		ld (@-clippable_1_column4), a
+		ret
+
+		DS ALIGN 0x0010
+		ex de, hl
+		ld a, 0xc9
+		ld (@-clippable_1_column3), a
+		call @-clippable_full_1
+		ld a, 0x36
+		ld (@-clippable_1_column3), a
+		ret
+
+		DS ALIGN 0x0010
+		ex de, hl
+		ld a, 0xc9
+		ld (@-clippable_1_column2), a
+		call @-clippable_full_1
+		ld a, 0x36
+		ld (@-clippable_1_column2), a
+		ret
+
+		DS ALIGN 0x0010
+		ex de, hl
+		ld a, 0xc9
+		ld (@-clippable_1_column1), a
+		call @-clippable_full_1
+		ld a, 0x36
+		ld (@-clippable_1_column1), a
 		ret
 
 		DS ALIGN 0x0100
@@ -2756,7 +2742,6 @@
 		jp @-clippable_full_0
 
 		DS ALIGN 0x0010
-	clippable_0_start_after1:
 		ex de, hl
 		ld bc, 0x0501
 		add hl, bc
@@ -2766,7 +2751,6 @@
 		jp @-clippable_0_column1
 
 		DS ALIGN 0x0010
-	clippable_0_start_after2:
 		ex de, hl
 		ld bc, 0x0402
 		add hl, bc
@@ -2776,7 +2760,6 @@
 		jp @-clippable_0_column2
 
 		DS ALIGN 0x0010
-	clippable_0_start_after3:
 		ex de, hl
 		ld bc, 0x0403
 		add hl, bc
@@ -2786,7 +2769,6 @@
 		jp @-clippable_0_column3
 
 		DS ALIGN 0x0010
-	clippable_0_start_after4:
 		ex de, hl
 		ld bc, 0x0504
 		add hl, bc
@@ -2796,7 +2778,6 @@
 		jp @-clippable_0_column4
 
 		DS ALIGN 0x0010
-	clippable_0_start_after5:
 		ex de, hl
 		ld bc, 0x0605
 		add hl, bc
@@ -2806,7 +2787,6 @@
 		jp @-clippable_0_column5
 
 		DS ALIGN 0x0010
-	clippable_0_start_after6:
 		ex de, hl
 		ld bc, 0x0606
 		add hl, bc
@@ -2816,7 +2796,6 @@
 		jp @-clippable_0_column6
 
 		DS ALIGN 0x0010
-	clippable_0_start_after7:
 		ex de, hl
 		ld bc, 0x0707
 		add hl, bc
@@ -2826,72 +2805,65 @@
 		jp @-clippable_0_column7
 
 		DS ALIGN 0x0010
-	clippable_0_stop_after1:
-		ex de, hl
-		ld a, 0xc9
-		ld (@-clippable_0_column1), a
-		call clippable_0
-		ld a, 0x72
-		ld (@-clippable_0_column1), a
-		ret
-
-		DS ALIGN 0x0010
-	clippable_0_stop_after2:
-		ex de, hl
-		ld a, 0xc9
-		ld (@-clippable_0_column2), a
-		call clippable_0
-		ld a, 0x36
-		ld (@-clippable_0_column2), a
-		ret
-
-		DS ALIGN 0x0010
-	clippable_0_stop_after3:
-		ex de, hl
-		ld a, 0xc9
-		ld (@-clippable_0_column3), a
-		call clippable_0
-		ld a, 0x36
-		ld (@-clippable_0_column3), a
-		ret
-
-		DS ALIGN 0x0010
-	clippable_0_stop_after4:
-		ex de, hl
-		ld a, 0xc9
-		ld (@-clippable_0_column4), a
-		call clippable_0
-		ld a, 0x36
-		ld (@-clippable_0_column4), a
-		ret
-
-		DS ALIGN 0x0010
-	clippable_0_stop_after5:
-		ex de, hl
-		ld a, 0xc9
-		ld (@-clippable_0_column5), a
-		call clippable_0
-		ld a, 0x72
-		ld (@-clippable_0_column5), a
-		ret
-
-		DS ALIGN 0x0010
-	clippable_0_stop_after6:
-		ex de, hl
-		ld a, 0xc9
-		ld (@-clippable_0_column6), a
-		call clippable_0
-		ld a, 0x36
-		ld (@-clippable_0_column6), a
-		ret
-
-		DS ALIGN 0x0010
-	clippable_0_stop_after7:
 		ex de, hl
 		ld a, 0xc9
 		ld (@-clippable_0_column7), a
-		call clippable_0
+		call @-clippable_full_0
 		ld a, 0x77
 		ld (@-clippable_0_column7), a
+		ret
+
+		DS ALIGN 0x0010
+		ex de, hl
+		ld a, 0xc9
+		ld (@-clippable_0_column6), a
+		call @-clippable_full_0
+		ld a, 0x36
+		ld (@-clippable_0_column6), a
+		ret
+
+		DS ALIGN 0x0010
+		ex de, hl
+		ld a, 0xc9
+		ld (@-clippable_0_column5), a
+		call @-clippable_full_0
+		ld a, 0x72
+		ld (@-clippable_0_column5), a
+		ret
+
+		DS ALIGN 0x0010
+		ex de, hl
+		ld a, 0xc9
+		ld (@-clippable_0_column4), a
+		call @-clippable_full_0
+		ld a, 0x36
+		ld (@-clippable_0_column4), a
+		ret
+
+		DS ALIGN 0x0010
+		ex de, hl
+		ld a, 0xc9
+		ld (@-clippable_0_column3), a
+		call @-clippable_full_0
+		ld a, 0x36
+		ld (@-clippable_0_column3), a
+		ret
+
+		DS ALIGN 0x0010
+		ex de, hl
+		ld a, 0xc9
+		ld (@-clippable_0_column2), a
+		call @-clippable_full_0
+		ld a, 0x36
+		ld (@-clippable_0_column2), a
+		ret
+
+		DS ALIGN 0x0010
+		ex de, hl
+		ld a, 0xc9
+		ld (@-clippable_0_column1), a
+		call @-clippable_full_0
+		ld a, 0x72
+		ld (@-clippable_0_column1), a
 		ret
 

--- a/src/generated/sprites.z80s
+++ b/src/generated/sprites.z80s
@@ -2327,126 +2327,6 @@
 		ld (hl), d
 		ret
 
-		DS ALIGN 0x0100
-	@clippable_1_dispatch:
-		DS ALIGN 0x0010
-	clippable_1_start_after1:
-		ld bc, 0x0101
-		add hl, bc
-		ld bc, 0xfd81
-		ld d, 0x4a
-		jp @-clippable_1_column1
-		DS ALIGN 0x0010
-	clippable_1_start_after2:
-		ld bc, 0x0002
-		add hl, bc
-		ld a, 0xaa
-		ld bc, 0xf981
-		ld de, 0x4aa4
-		jp @-clippable_1_column2
-		DS ALIGN 0x0010
-	clippable_1_start_after3:
-		ld bc, 0x0003
-		add hl, bc
-		ld a, 0xaa
-		ld bc, 0xf681
-		ld de, 0x4aa4
-		jp @-clippable_1_column3
-		DS ALIGN 0x0010
-	clippable_1_start_after4:
-		ld bc, 0x0104
-		add hl, bc
-		ld a, 0xaa
-		ld bc, 0xf681
-		ld de, 0x4aa4
-		jp @-clippable_1_column4
-		DS ALIGN 0x0010
-	clippable_1_start_after5:
-		ld bc, 0x0205
-		add hl, bc
-		ld a, 0xaa
-		ld bc, 0xf681
-		ld de, 0x4aa4
-		jp @-clippable_1_column5
-		DS ALIGN 0x0010
-	clippable_1_start_after6:
-		ld bc, 0x0206
-		add hl, bc
-		ld a, 0xaa
-		ld bc, 0xf681
-		ld de, 0x4aa4
-		jp @-clippable_1_column6
-		DS ALIGN 0x0010
-	clippable_1_start_after7:
-		ld bc, 0x0307
-		add hl, bc
-		ld a, 0xaa
-		ld bc, 0xf881
-		ld de, 0x4aa4
-		jp @-clippable_1_column7
-		DS ALIGN 0x0010
-	clippable_1_stop_after1:
-		ld a, 0xc9
-		ld (@-clippable_1_column1), a
-		call clippable_1
-		ld a, 0x36
-		ld (@-clippable_1_column1), a
-		ret
-
-		DS ALIGN 0x0010
-	clippable_1_stop_after2:
-		ld a, 0xc9
-		ld (@-clippable_1_column2), a
-		call clippable_1
-		ld a, 0x36
-		ld (@-clippable_1_column2), a
-		ret
-
-		DS ALIGN 0x0010
-	clippable_1_stop_after3:
-		ld a, 0xc9
-		ld (@-clippable_1_column3), a
-		call clippable_1
-		ld a, 0x36
-		ld (@-clippable_1_column3), a
-		ret
-
-		DS ALIGN 0x0010
-	clippable_1_stop_after4:
-		ld a, 0xc9
-		ld (@-clippable_1_column4), a
-		call clippable_1
-		ld a, 0x36
-		ld (@-clippable_1_column4), a
-		ret
-
-		DS ALIGN 0x0010
-	clippable_1_stop_after5:
-		ld a, 0xc9
-		ld (@-clippable_1_column5), a
-		call clippable_1
-		ld a, 0x36
-		ld (@-clippable_1_column5), a
-		ret
-
-		DS ALIGN 0x0010
-	clippable_1_stop_after6:
-		ld a, 0xc9
-		ld (@-clippable_1_column6), a
-		call clippable_1
-		ld a, 0x36
-		ld (@-clippable_1_column6), a
-		ret
-
-		DS ALIGN 0x0010
-	clippable_1_stop_after7:
-		ld a, 0xc9
-		ld (@-clippable_1_column7), a
-		call clippable_1
-		ld a, 0x36
-		ld (@-clippable_1_column7), a
-		ret
-
 	clippable_0:
 		ld bc, 0x0500
 		add hl, bc
@@ -2705,6 +2585,130 @@
 		ld (hl), e
 		inc h
 		ld (hl), a
+		ret
+
+	; From here downwards are dispatch groups for 'clippables', i.e. those sprites that have been
+	; formulated such that they can be drawn with any number of columns removed from either the left-
+	; right-hand sides.
+
+		DS ALIGN 0x0100
+	@clippable_1_dispatch:
+		DS ALIGN 0x0010
+	clippable_1_start_after1:
+		ld bc, 0x0101
+		add hl, bc
+		ld bc, 0xfd81
+		ld d, 0x4a
+		jp @-clippable_1_column1
+		DS ALIGN 0x0010
+	clippable_1_start_after2:
+		ld bc, 0x0002
+		add hl, bc
+		ld a, 0xaa
+		ld bc, 0xf981
+		ld de, 0x4aa4
+		jp @-clippable_1_column2
+		DS ALIGN 0x0010
+	clippable_1_start_after3:
+		ld bc, 0x0003
+		add hl, bc
+		ld a, 0xaa
+		ld bc, 0xf681
+		ld de, 0x4aa4
+		jp @-clippable_1_column3
+		DS ALIGN 0x0010
+	clippable_1_start_after4:
+		ld bc, 0x0104
+		add hl, bc
+		ld a, 0xaa
+		ld bc, 0xf681
+		ld de, 0x4aa4
+		jp @-clippable_1_column4
+		DS ALIGN 0x0010
+	clippable_1_start_after5:
+		ld bc, 0x0205
+		add hl, bc
+		ld a, 0xaa
+		ld bc, 0xf681
+		ld de, 0x4aa4
+		jp @-clippable_1_column5
+		DS ALIGN 0x0010
+	clippable_1_start_after6:
+		ld bc, 0x0206
+		add hl, bc
+		ld a, 0xaa
+		ld bc, 0xf681
+		ld de, 0x4aa4
+		jp @-clippable_1_column6
+		DS ALIGN 0x0010
+	clippable_1_start_after7:
+		ld bc, 0x0307
+		add hl, bc
+		ld a, 0xaa
+		ld bc, 0xf881
+		ld de, 0x4aa4
+		jp @-clippable_1_column7
+		DS ALIGN 0x0010
+	clippable_1_stop_after1:
+		ld a, 0xc9
+		ld (@-clippable_1_column1), a
+		call clippable_1
+		ld a, 0x36
+		ld (@-clippable_1_column1), a
+		ret
+
+		DS ALIGN 0x0010
+	clippable_1_stop_after2:
+		ld a, 0xc9
+		ld (@-clippable_1_column2), a
+		call clippable_1
+		ld a, 0x36
+		ld (@-clippable_1_column2), a
+		ret
+
+		DS ALIGN 0x0010
+	clippable_1_stop_after3:
+		ld a, 0xc9
+		ld (@-clippable_1_column3), a
+		call clippable_1
+		ld a, 0x36
+		ld (@-clippable_1_column3), a
+		ret
+
+		DS ALIGN 0x0010
+	clippable_1_stop_after4:
+		ld a, 0xc9
+		ld (@-clippable_1_column4), a
+		call clippable_1
+		ld a, 0x36
+		ld (@-clippable_1_column4), a
+		ret
+
+		DS ALIGN 0x0010
+	clippable_1_stop_after5:
+		ld a, 0xc9
+		ld (@-clippable_1_column5), a
+		call clippable_1
+		ld a, 0x36
+		ld (@-clippable_1_column5), a
+		ret
+
+		DS ALIGN 0x0010
+	clippable_1_stop_after6:
+		ld a, 0xc9
+		ld (@-clippable_1_column6), a
+		call clippable_1
+		ld a, 0x36
+		ld (@-clippable_1_column6), a
+		ret
+
+		DS ALIGN 0x0010
+	clippable_1_stop_after7:
+		ld a, 0xc9
+		ld (@-clippable_1_column7), a
+		call clippable_1
+		ld a, 0x36
+		ld (@-clippable_1_column7), a
 		ret
 
 		DS ALIGN 0x0100

--- a/src/generated/sprites.z80s
+++ b/src/generated/sprites.z80s
@@ -2590,66 +2590,98 @@
 	; From here downwards are dispatch groups for 'clippables', i.e. those sprites that have been
 	; formulated such that they can be drawn with any number of columns removed from either the left-
 	; right-hand sides.
-
+	;
+	; Each dispatch group is aligned to a 256-byte boundary in memory and consists primarily of
+	; a series of 16-byte routines, after an establishing 16-byte block.
+	;
+	; The first thing in the establishing block is a JP to the routine that draws the whole sprite.
+	; Immediately after that is a JP to the routine that will properly mark dirty bits for this sprite size.
+	;
+	; Call the first routine after the establishing block to output the sprite with the leftmost column
+	; removed. Call the second to output with the two leftmost columns removed. And so on, up to and
+	; including the seventh function.
+	;
+	; Call the eighth function to output the sprite with the rightmost column removed. Call the ninth
+	; to output with the two rightmost columns removed. Etc.
+	;
+	; The clipping functions should be called with the nominal screen destination of the top left corner
+	; in DE.
 		DS ALIGN 0x0100
 	@clippable_1_dispatch:
+		jp clippable_1
+
 		DS ALIGN 0x0010
 	clippable_1_start_after1:
+		ex de, hl
 		ld bc, 0x0101
 		add hl, bc
 		ld bc, 0xfd81
 		ld d, 0x4a
 		jp @-clippable_1_column1
+
 		DS ALIGN 0x0010
 	clippable_1_start_after2:
+		ex de, hl
 		ld bc, 0x0002
 		add hl, bc
 		ld a, 0xaa
 		ld bc, 0xf981
 		ld de, 0x4aa4
 		jp @-clippable_1_column2
+
 		DS ALIGN 0x0010
 	clippable_1_start_after3:
+		ex de, hl
 		ld bc, 0x0003
 		add hl, bc
 		ld a, 0xaa
 		ld bc, 0xf681
 		ld de, 0x4aa4
 		jp @-clippable_1_column3
+
 		DS ALIGN 0x0010
 	clippable_1_start_after4:
+		ex de, hl
 		ld bc, 0x0104
 		add hl, bc
 		ld a, 0xaa
 		ld bc, 0xf681
 		ld de, 0x4aa4
 		jp @-clippable_1_column4
+
 		DS ALIGN 0x0010
 	clippable_1_start_after5:
+		ex de, hl
 		ld bc, 0x0205
 		add hl, bc
 		ld a, 0xaa
 		ld bc, 0xf681
 		ld de, 0x4aa4
 		jp @-clippable_1_column5
+
 		DS ALIGN 0x0010
 	clippable_1_start_after6:
+		ex de, hl
 		ld bc, 0x0206
 		add hl, bc
 		ld a, 0xaa
 		ld bc, 0xf681
 		ld de, 0x4aa4
 		jp @-clippable_1_column6
+
 		DS ALIGN 0x0010
 	clippable_1_start_after7:
+		ex de, hl
 		ld bc, 0x0307
 		add hl, bc
 		ld a, 0xaa
 		ld bc, 0xf881
 		ld de, 0x4aa4
 		jp @-clippable_1_column7
+
 		DS ALIGN 0x0010
 	clippable_1_stop_after1:
+		ex de, hl
 		ld a, 0xc9
 		ld (@-clippable_1_column1), a
 		call clippable_1
@@ -2659,6 +2691,7 @@
 
 		DS ALIGN 0x0010
 	clippable_1_stop_after2:
+		ex de, hl
 		ld a, 0xc9
 		ld (@-clippable_1_column2), a
 		call clippable_1
@@ -2668,6 +2701,7 @@
 
 		DS ALIGN 0x0010
 	clippable_1_stop_after3:
+		ex de, hl
 		ld a, 0xc9
 		ld (@-clippable_1_column3), a
 		call clippable_1
@@ -2677,6 +2711,7 @@
 
 		DS ALIGN 0x0010
 	clippable_1_stop_after4:
+		ex de, hl
 		ld a, 0xc9
 		ld (@-clippable_1_column4), a
 		call clippable_1
@@ -2686,6 +2721,7 @@
 
 		DS ALIGN 0x0010
 	clippable_1_stop_after5:
+		ex de, hl
 		ld a, 0xc9
 		ld (@-clippable_1_column5), a
 		call clippable_1
@@ -2695,6 +2731,7 @@
 
 		DS ALIGN 0x0010
 	clippable_1_stop_after6:
+		ex de, hl
 		ld a, 0xc9
 		ld (@-clippable_1_column6), a
 		call clippable_1
@@ -2704,6 +2741,7 @@
 
 		DS ALIGN 0x0010
 	clippable_1_stop_after7:
+		ex de, hl
 		ld a, 0xc9
 		ld (@-clippable_1_column7), a
 		call clippable_1
@@ -2713,64 +2751,81 @@
 
 		DS ALIGN 0x0100
 	@clippable_0_dispatch:
+		jp clippable_0
+
 		DS ALIGN 0x0010
 	clippable_0_start_after1:
+		ex de, hl
 		ld bc, 0x0501
 		add hl, bc
 		ld a, 0xaa
 		ld bc, 0xf981
 		ld de, 0x44a4
 		jp @-clippable_0_column1
+
 		DS ALIGN 0x0010
 	clippable_0_start_after2:
+		ex de, hl
 		ld bc, 0x0402
 		add hl, bc
 		ld a, 0xaa
 		ld bc, 0xf881
 		ld de, 0x44a4
 		jp @-clippable_0_column2
+
 		DS ALIGN 0x0010
 	clippable_0_start_after3:
+		ex de, hl
 		ld bc, 0x0403
 		add hl, bc
 		ld a, 0xaa
 		ld bc, 0xf881
 		ld de, 0x44a4
 		jp @-clippable_0_column3
+
 		DS ALIGN 0x0010
 	clippable_0_start_after4:
+		ex de, hl
 		ld bc, 0x0504
 		add hl, bc
 		ld a, 0xaa
 		ld bc, 0xf981
 		ld de, 0x44a4
 		jp @-clippable_0_column4
+
 		DS ALIGN 0x0010
 	clippable_0_start_after5:
+		ex de, hl
 		ld bc, 0x0605
 		add hl, bc
 		ld a, 0xaa
 		ld bc, 0xfa81
 		ld de, 0x44a4
 		jp @-clippable_0_column5
+
 		DS ALIGN 0x0010
 	clippable_0_start_after6:
+		ex de, hl
 		ld bc, 0x0606
 		add hl, bc
 		ld a, 0xaa
 		ld bc, 0xfa81
 		ld de, 0x44a4
 		jp @-clippable_0_column6
+
 		DS ALIGN 0x0010
 	clippable_0_start_after7:
+		ex de, hl
 		ld bc, 0x0707
 		add hl, bc
 		ld a, 0x40
 		ld bc, 0xfb81
 		ld de, 0x44a4
 		jp @-clippable_0_column7
+
 		DS ALIGN 0x0010
 	clippable_0_stop_after1:
+		ex de, hl
 		ld a, 0xc9
 		ld (@-clippable_0_column1), a
 		call clippable_0
@@ -2780,6 +2835,7 @@
 
 		DS ALIGN 0x0010
 	clippable_0_stop_after2:
+		ex de, hl
 		ld a, 0xc9
 		ld (@-clippable_0_column2), a
 		call clippable_0
@@ -2789,6 +2845,7 @@
 
 		DS ALIGN 0x0010
 	clippable_0_stop_after3:
+		ex de, hl
 		ld a, 0xc9
 		ld (@-clippable_0_column3), a
 		call clippable_0
@@ -2798,6 +2855,7 @@
 
 		DS ALIGN 0x0010
 	clippable_0_stop_after4:
+		ex de, hl
 		ld a, 0xc9
 		ld (@-clippable_0_column4), a
 		call clippable_0
@@ -2807,6 +2865,7 @@
 
 		DS ALIGN 0x0010
 	clippable_0_stop_after5:
+		ex de, hl
 		ld a, 0xc9
 		ld (@-clippable_0_column5), a
 		call clippable_0
@@ -2816,6 +2875,7 @@
 
 		DS ALIGN 0x0010
 	clippable_0_stop_after6:
+		ex de, hl
 		ld a, 0xc9
 		ld (@-clippable_0_column6), a
 		call clippable_0
@@ -2825,6 +2885,7 @@
 
 		DS ALIGN 0x0010
 	clippable_0_stop_after7:
+		ex de, hl
 		ld a, 0xc9
 		ld (@-clippable_0_column7), a
 		call clippable_0

--- a/src/player_display.z80s
+++ b/src/player_display.z80s
@@ -1,54 +1,16 @@
 @player_walk_count:	db 0	; Counts number of frames the player has been walking on the ground for, affecting current frame.
 
-@clippable_x: db 130
+@clippable_x: db 250
 
 ;
 ; Draws the player sprite and flags appropriate dirty spots.
 ;
 draw_player_sprite:
-	; TEST! Draw a clippable that moves left-to-right and back again.
-	ld d, 0
-	ld a, START_X
-	ld h, clippable_0 >> 8
-	call draw_clippable
-
+	; TEST! Draw a clippable that moves left-to-right and then overflows back to the left.
 	ld d, 12
-	ld a, START_X - 1
-	ld h, clippable_0 >> 8
-	call draw_clippable
-
-	ld d, 24
-	ld a, START_X - 2
-	ld h, clippable_0 >> 8
-	call draw_clippable
-
-	ld d, 36
-	ld a, START_X - 3
-	ld h, clippable_0 >> 8
-	call draw_clippable
-
-	ld d, 48
-	ld a, START_X - 4
-	ld h, clippable_0 >> 8
-	call draw_clippable
-
-	ld d, 60
-	ld a, START_X - 5
-	ld h, clippable_0 >> 8
-	call draw_clippable
-
-	ld d, 72
-	ld a, START_X - 6
-	ld h, clippable_0 >> 8
-	call draw_clippable
-
-	ld d, 84
-	ld a, START_X - 7
-	ld h, clippable_0 >> 8
-	call draw_clippable
-
-	ld d, 96
-	ld a, START_X - 8
+	ld a, (@-clippable_x)
+	inc a
+	ld (@-clippable_x), a
 	ld h, clippable_0 >> 8
 	call draw_clippable
 
@@ -135,7 +97,7 @@ draw_player_sprite:
 draw_clippable:
 	; Test for right boundary.
 	; The -8 embeds an assumption that clippables are 16px i.e. 8 bytes across.
-	cp START_X + 128 - 8
+	cp START_X + 128 - 7 + 1
 	jp nc, @+test_right_clip
 
 	; Test for left boundary.
@@ -146,6 +108,7 @@ draw_clippable:
 	; Dispatch via the jump located at the start of the clippable page.
 	ld l, 0
 	sub START_X
+	add a
 	ld e, a
 	scf
 	rr d
@@ -159,7 +122,7 @@ draw_clippable:
 
 	; Convert to a jump location, calculate screen location and go.
 	ld e, a
-	sub START_X + 128 - 7 + 8
+	sub START_X + (128 - 7) - 8
 	rlca
 	rlca
 	rlca
@@ -183,7 +146,7 @@ draw_clippable:
 	ret c
 
 	ld e, a
-	cpl
+	cpl			; TODO: can I rearrange the dispatch group to avoid this cpl?
 	add START_X + 1
 	rlca
 	rlca

--- a/src/player_display.z80s
+++ b/src/player_display.z80s
@@ -1,18 +1,18 @@
 @player_walk_count:	db 0	; Counts number of frames the player has been walking on the ground for, affecting current frame.
 
-@clippable_x: db 250
+; @clippable_x: db 250
 
 ;
 ; Draws the player sprite and flags appropriate dirty spots.
 ;
 draw_player_sprite:
 	; TEST! Draw a clippable that moves left-to-right and then overflows back to the left.
-	ld d, 12
-	ld a, (@-clippable_x)
-	inc a
-	ld (@-clippable_x), a
-	ld h, clippable_0 >> 8
-	call draw_clippable
+	; ld d, 12
+	; ld a, (@-clippable_x)
+	; inc a
+	; ld (@-clippable_x), a
+	; ld h, clippable_0 >> 8
+	; call draw_clippable
 
 	; Load y, subtract origin, multiply it by 128 and set the top bit.
 	ld l, 0

--- a/src/player_display.z80s
+++ b/src/player_display.z80s
@@ -79,3 +79,71 @@ draw_player_sprite:
 	ld a, (player_current+Y_OFFSET+1)
 	ld c, a
 	jp mark16x24
+
+
+;
+; Draws the clippable indicated by H in the location defined by D = y, A = x.
+;
+draw_clippable:
+	; Test for right boundary.
+	; The -8 embeds an assumption that clippables are 16px i.e. 8 bytes across.
+	cp START_X + 128 - 8
+	jp nc, @+test_right_clip
+
+	; Test for left boundary.
+	cp START_X
+	jp c, @+test_left_clip
+
+	; No clipping required. That was easy!
+	; Dispatch via the jump located at the start of the clippable page.
+	ld l, 0
+	sub START_X
+	ld e, a
+	scf
+	rr d
+	rr e
+	jp (hl)
+
+@test_right_clip:
+	; Exit early if clippable is entirely off the right-hand side of the display.
+	cp START_X + 128
+	ret nc
+
+	; Convert to a jump location, calculate screen location and go.
+	sub START_X + 128 - 7 + 8
+	rlca
+	rlca
+	rlca
+	rlca
+	ld l, a
+
+	; Copy and pasted from above. Pyz80 has no macros, I think?
+	sub START_X
+	ld e, a
+	scf
+	rr d
+	rr e
+
+	jp (hl)
+
+@test_left_clip:
+	; Exit early if clippable is entirely off the left-hand side of the display.
+	cp START_X - 8
+	ret c
+
+	cpl
+	add START_X + 2
+	rlca
+	rlca
+	rlca
+	rlca
+	ld l, a
+
+	; Copy and pasted from above. Pyz80 has no macros, I think?
+	sub START_X
+	ld e, a
+	scf
+	rr d
+	rr e
+
+	jp (hl)

--- a/src/player_display.z80s
+++ b/src/player_display.z80s
@@ -1,9 +1,57 @@
 @player_walk_count:	db 0	; Counts number of frames the player has been walking on the ground for, affecting current frame.
 
+@clippable_x: db 130
+
 ;
 ; Draws the player sprite and flags appropriate dirty spots.
 ;
 draw_player_sprite:
+	; TEST! Draw a clippable that moves left-to-right and back again.
+	ld d, 0
+	ld a, START_X
+	ld h, clippable_0 >> 8
+	call draw_clippable
+
+	ld d, 12
+	ld a, START_X - 1
+	ld h, clippable_0 >> 8
+	call draw_clippable
+
+	ld d, 24
+	ld a, START_X - 2
+	ld h, clippable_0 >> 8
+	call draw_clippable
+
+	ld d, 36
+	ld a, START_X - 3
+	ld h, clippable_0 >> 8
+	call draw_clippable
+
+	ld d, 48
+	ld a, START_X - 4
+	ld h, clippable_0 >> 8
+	call draw_clippable
+
+	ld d, 60
+	ld a, START_X - 5
+	ld h, clippable_0 >> 8
+	call draw_clippable
+
+	ld d, 72
+	ld a, START_X - 6
+	ld h, clippable_0 >> 8
+	call draw_clippable
+
+	ld d, 84
+	ld a, START_X - 7
+	ld h, clippable_0 >> 8
+	call draw_clippable
+
+	ld d, 96
+	ld a, START_X - 8
+	ld h, clippable_0 >> 8
+	call draw_clippable
+
 	; Load y, subtract origin, multiply it by 128 and set the top bit.
 	ld l, 0
 	ld a, (player_current+Y_OFFSET+1)
@@ -110,15 +158,18 @@ draw_clippable:
 	ret nc
 
 	; Convert to a jump location, calculate screen location and go.
+	ld e, a
 	sub START_X + 128 - 7 + 8
 	rlca
 	rlca
 	rlca
 	rlca
 	ld l, a
+	ld a, e
 
 	; Copy and pasted from above. Pyz80 has no macros, I think?
 	sub START_X
+	add a
 	ld e, a
 	scf
 	rr d
@@ -128,20 +179,24 @@ draw_clippable:
 
 @test_left_clip:
 	; Exit early if clippable is entirely off the left-hand side of the display.
-	cp START_X - 8
+	cp START_X - 8 + 1
 	ret c
 
+	ld e, a
 	cpl
-	add START_X + 2
+	add START_X + 1
 	rlca
 	rlca
 	rlca
 	rlca
 	ld l, a
+	ld a, e
 
 	; Copy and pasted from above. Pyz80 has no macros, I think?
 	sub START_X
+	add a
 	ld e, a
+	dec d
 	scf
 	rr d
 	rr e


### PR DESCRIPTION
Observation: there are 14 sets of 16-byte clipped dispatched functions per 16-column clippable. So that's very close to filling 256 bytes; assuming I add JPs for drawing the full-size sprite and for setting the proper mask, and that the flippable sprites are 16px wide, each actually fills 230 bytes total.

So it makes sense to keep them separately and together, as the cost of 256-byte alignment will then be small.

Also adds an appropriate dispatch function to call into the proper dispatch function, though there's no clipping dirty marking yet so the formal introduction of sprites into the world will have to wait.